### PR TITLE
Provide a URL/ServerUrl extension, and extension loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#7](https://github.com/zendframework/zend-expressive-platesrenderer/pull/7)
+  adds:
+  - `Zend\Expressive\Plates\PlatesEngineFactory`, which will create and return a
+    `League\Plates\Engine` instance. It introspects the `plates.extensions`
+    configuration to optionally load extensions into the engine; that value must
+    be an array of:
+    - extension instances
+    - string service names resolving to extension instances
+    - string class names resolving to extension instances
+  - `Zend\Expressive\Plates\Extension\UrlExtension`, which provides a wrapper
+    around the `UrlHelper` and `ServerUrlHelper` from zend-expressive-helpers,
+    as the functions `url($route = null, array $params = []) : string` and
+    `serverurl($path = null) : string`, respectively.
+  - `Zend\Expressive\Plates\Extension\UrlExtensionFactory`, which provides a
+    factory for creating the `UrlExtension`.
 
 ### Deprecated
 
@@ -18,7 +32,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#7](https://github.com/zendframework/zend-expressive-platesrenderer/pull/7)
+  updates `PlatesRendererFactory` to use either the `League\Plates\Engine`
+  service, if available, or the new `PlatesEngineFactory` to create the Plates
+  engine instance. This also ensures the `url()` and `serverurl()` functions are
+  registered by default.
 
 ## 1.0.1 - TBD
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "league/plates": "^3.1",
-        "zendframework/zend-expressive-template": "^1.0"
+        "zendframework/zend-expressive-template": "^1.0",
+        "zendframework/zend-expressive-helpers": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Exception/InvalidExtensionException.php
+++ b/src/Exception/InvalidExtensionException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates\Exception;
+
+use Interop\Container\Exception\ContainerException;
+use RuntimeException;
+
+class InvalidExtensionException extends RuntimeException implements
+    ExceptionInterface,
+    ContainerException
+{
+}

--- a/src/Exception/MissingHelperException.php
+++ b/src/Exception/MissingHelperException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates\Exception;
+
+use Interop\Container\Exception\ContainerException;
+use RuntimeException;
+
+class MissingHelperException extends RuntimeException implements
+    ExceptionInterface,
+    ContainerException
+{
+}

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates\Extension;
+
+use League\Plates\Engine;
+use League\Plates\Extension\ExtensionInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+
+class UrlExtension implements ExtensionInterface
+{
+    /**
+     * @var ServerUrlHelper
+     */
+    private $serverUrlHelper;
+
+    /**
+     * @var UrlHelper
+     */
+    private $urlHelper;
+
+    /**
+     * @param UrlHelper $urlHelper
+     * @param ServerUrlHelper $serverUrlHelper
+     */
+    public function __construct(UrlHelper $urlHelper, ServerUrlHelper $serverUrlHelper)
+    {
+        $this->urlHelper = $urlHelper;
+        $this->serverUrlHelper = $serverUrlHelper;
+    }
+
+    /**
+     * Register functions with the Plates engine.
+     *
+     * Registers:
+     *
+     * - url($route = null, array $params = []) : string
+     * - serverurl($path = null) : string
+     *
+     * @param Engine $engine
+     * @return void
+     */
+    public function register(Engine $engine)
+    {
+        $engine->registerFunction('url', [$this, 'generateUrl']);
+        $engine->registerFunction('serverurl', [$this, 'generateServerUrl']);
+    }
+
+    /**
+     * Generate a URL from either the currently matched route or the specfied route.
+     *
+     * @param null|string $route Name of route from which to generate URL.
+     * @param array $params Route substitution parameters
+     * @return string
+     */
+    public function generateUrl($route = null, array $params = [])
+    {
+        return $this->urlHelper->generate($route, $params);
+    }
+
+    /**
+     * Generate a fully qualified URI, relative to $path.
+     *
+     * @param null|string $path
+     * @return string
+     */
+    public function generateServerUrl($path = null)
+    {
+        return $this->serverUrlHelper->generate($path);
+    }
+}

--- a/src/Extension/UrlExtensionFactory.php
+++ b/src/Extension/UrlExtensionFactory.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates\Extension;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Plates\Exception\MissingHelperException;
+
+/**
+ * Factory for creating a UrlExtension instance.
+ */
+class UrlExtensionFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @return UrlExtension
+     * @throws MissingHelperException if UrlHelper service is missing.
+     * @throws MissingHelperException if ServerUrlHelper service is missing.
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        if (! $container->has(UrlHelper::class)) {
+            throw new MissingHelperException(sprintf(
+                '%s requires that the %s service be present; not found',
+                UrlExtension::class,
+                UrlHelper::class
+            ));
+        }
+
+        if (! $container->has(ServerUrlHelper::class)) {
+            throw new MissingHelperException(sprintf(
+                '%s requires that the %s service be present; not found',
+                UrlExtension::class,
+                ServerUrlHelper::class
+            ));
+        }
+
+        return new UrlExtension(
+            $container->get(UrlHelper::class),
+            $container->get(ServerUrlHelper::class)
+        );
+    }
+}

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Plates;
+
+use Interop\Container\ContainerInterface;
+use League\Plates\Engine as PlatesEngine;
+use League\Plates\Extension\ExtensionInterface;
+
+/**
+ * Create and return a Plates engine instance.
+ *
+ * Optionally uses the service 'config', which should return an array. This
+ * factory consumes the following structure:
+ *
+ * <code>
+ * 'plates' => [
+ *     'extensions' => [
+ *         // extension instances, or
+ *         // service names that return extension instances, or
+ *         // class names of directly instantiable extensions.
+ *     ]
+ * ]
+ * </code>
+ *
+ * By default, this factory attaches the Extension\UrlExtension to
+ * the engine. You can override the functions that extension exposes
+ * by providing an extension class in your extensions array, or providing
+ * an alternative Zend\Expressive\Plates\Extension\UrlExtension service.
+ */
+class PlatesEngineFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @return PlatesEngine
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = isset($config['plates']) ? $config['plates'] : [];
+
+        // Create the engine instance:
+        $engine = new PlatesEngine();
+
+        $this->injectUrlExtension($container, $engine);
+
+        if (isset($config['extensions']) && is_array($config['extensions'])) {
+            $this->injectExtensions($container, $engine, $config['extensions']);
+        }
+
+        return $engine;
+    }
+
+    /**
+     * Inject the URL/ServerUrl extensions provided by this package.
+     *
+     * If a service by the name of the UrlExtension class exists, fetches
+     * and loads it.
+     *
+     * Otherwise, instantiates the UrlExtensionFactory, and invokes it with
+     * the container, loading the result into the engine.
+     *
+     * @param ContainerInterface $container
+     * @param PlatesEngine $engine
+     * @return void
+     */
+    private function injectUrlExtension(ContainerInterface $container, PlatesEngine $engine)
+    {
+        if ($container->has(Extension\UrlExtension::class)) {
+            $engine->loadExtension($container->get(Extension\UrlExtension::class));
+            return;
+        }
+
+        $extensionFactory = new Extension\UrlExtensionFactory();
+        $engine->loadExtension($extensionFactory($container));
+    }
+
+    /**
+     * Inject all configured extensions into the engine.
+     * @param ContainerInterface $container
+     * @param PlatesEngine $engine
+     * @param array $extensions
+     * @return void
+     */
+    private function injectExtensions(ContainerInterface $container, PlatesEngine $engine, array $extensions)
+    {
+        foreach ($extensions as $extension) {
+            $this->injectExtension($container, $engine, $extension);
+        }
+    }
+
+    /**
+     * Inject an extension into the engine.
+     *
+     * Valid extension specifications include:
+     *
+     * - ExtensionInterface instances
+     * - String service names that resolve to ExtensionInterface instances
+     * - String class names that resolve to ExtensionInterface instances
+     *
+     * If anything else is provided, an exception is raised.
+     *
+     * @param ContainerInterface $container
+     * @param PlatesEngine $engine
+     * @param ExtensionInterface|string $extension
+     * @return void
+     * @throws Exception\InvalidExtensionException for non-string,
+     *     non-extension $extension values.
+     * @throws Exception\InvalidExtensionException for string $extension values
+     *     that do not resolve to an extension instance.
+     */
+    private function injectExtension(ContainerInterface $container, PlatesEngine $engine, $extension)
+    {
+        if ($extension instanceof ExtensionInterface) {
+            $engine->loadExtension($extension);
+            return;
+        }
+
+        if (! is_string($extension)) {
+            throw new Exception\InvalidExtensionException(sprintf(
+                '%s expects extension instances, service names, or class names; received %s',
+                __CLASS__,
+                (is_object($extension) ? get_class($extension) : gettype($extension))
+            ));
+        }
+
+        if ($container->has($extension)) {
+            $engine->loadExtension($container->get($extension));
+            return;
+        }
+
+        if (class_exists($extension)) {
+            $engine->loadExtension(new $extension());
+            return;
+        }
+
+        throw new Exception\InvalidExtensionException(sprintf(
+            '%s expects extension service names or class names; "%s" does not resolve to either',
+            __CLASS__,
+            $extension
+        ));
+    }
+}

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -29,6 +29,10 @@ use League\Plates\Engine as PlatesEngine;
  *     ],
  * ]
  * </code>
+ *
+ * If the service League\Plates\Engine exists, that value will be used
+ * for the PlatesEngine; otherwise, this factory invokes the PlatesEngineFactory
+ * to create an instance.
  */
 class PlatesRendererFactory
 {
@@ -42,7 +46,7 @@ class PlatesRendererFactory
         $config = isset($config['templates']) ? $config['templates'] : [];
 
         // Create the engine instance:
-        $engine = new PlatesEngine();
+        $engine = $this->createEngine($container);
 
         // Set file extension
         if (isset($config['extension'])) {
@@ -62,5 +66,26 @@ class PlatesRendererFactory
         }
 
         return $plates;
+    }
+
+    /**
+     * Create and return a Plates Engine instance.
+     *
+     * If the container has the League\Plates\Engine service, returns it.
+     *
+     * Otherwise, invokes the PlatesEngineFactory with the $container to create
+     * and return the instance.
+     *
+     * @param ContainerInterface $container
+     * @return PlatesEngine
+     */
+    private function createEngine(ContainerInterface $container)
+    {
+        if ($container->has(PlatesEngine::class)) {
+            return $container->get(PlatesEngine::class);
+        }
+
+        $engineFactory = new PlatesEngineFactory();
+        return $engineFactory($container);
     }
 }

--- a/test/Extension/UrlExtensionFactoryTest.php
+++ b/test/Extension/UrlExtensionFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Plates\Extension;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Plates\Exception\MissingHelperException;
+use Zend\Expressive\Plates\Extension\UrlExtension;
+use Zend\Expressive\Plates\Extension\UrlExtensionFactory;
+
+class UrlExtensionFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->urlHelper = $this->prophesize(UrlHelper::class);
+        $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
+    }
+
+    public function testFactoryReturnsUrlExtensionInstanceWhenHelpersArePresent()
+    {
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($this->urlHelper->reveal());
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($this->serverUrlHelper->reveal());
+
+        $factory = new UrlExtensionFactory();
+        $extension = $factory($this->container->reveal());
+        $this->assertInstanceOf(UrlExtension::class, $extension);
+
+        $this->assertAttributeSame($this->urlHelper->reveal(), 'urlHelper', $extension);
+        $this->assertAttributeSame($this->serverUrlHelper->reveal(), 'serverUrlHelper', $extension);
+    }
+
+    public function testFactoryRaisesExceptionIfUrlHelperIsMissing()
+    {
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $this->container->get(UrlHelper::class)->shouldNotBeCalled();
+        $this->container->has(ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
+
+        $factory = new UrlExtensionFactory();
+
+        $this->setExpectedException(MissingHelperException::class, UrlHelper::class);
+        $factory($this->container->reveal());
+    }
+
+    public function testFactoryRaisesExceptionIfServerUrlHelperIsMissing()
+    {
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->shouldNotBeCalled();
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
+
+        $factory = new UrlExtensionFactory();
+
+        $this->setExpectedException(MissingHelperException::class, ServerUrlHelper::class);
+        $factory($this->container->reveal());
+    }
+}

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Plates\Extension;
+
+use League\Plates\Engine;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Plates\Extension\UrlExtension;
+
+class UrlExtensionTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->urlHelper = $this->prophesize(UrlHelper::class);
+        $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
+
+        $this->extension = new UrlExtension(
+            $this->urlHelper->reveal(),
+            $this->serverUrlHelper->reveal()
+        );
+    }
+
+    public function testRegistersUrlFunctionWithEngine()
+    {
+        $engine = $this->prophesize(Engine::class);
+        $engine->registerFunction(
+            'url',
+            [$this->extension, 'generateUrl']
+        )->shouldBeCalled();
+        $engine->registerFunction(
+            'serverurl',
+            [$this->extension, 'generateServerUrl']
+        )->shouldBeCalled();
+
+        $this->extension->register($engine->reveal());
+    }
+
+    public function urlHelperParams()
+    {
+        return [
+            'null' => [null, []],
+            'route-only' => ['route', []],
+            'params-only' => [null, ['param' => 'value']],
+            'route-and-params' => ['route', ['param' => 'value']],
+        ];
+    }
+
+    /**
+     * @dataProvider urlHelperParams
+     */
+    public function testGenerateUrlProxiesToUrlHelper($route, array $params)
+    {
+        $this->urlHelper->generate($route, $params)->willReturn('/success');
+        $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
+    }
+
+    public function serverUrlHelperParams()
+    {
+        return [
+            'null' => [null],
+            'absolute-path' => ['/foo/bar'],
+            'relative-path' => ['foo/bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider serverUrlHelperParams
+     */
+    public function testGenerateServerUrlProxiesToServerUrlHelper($path)
+    {
+        $this->serverUrlHelper->generate($path)->willReturn('/success');
+        $this->assertEquals('/success', $this->extension->generateServerUrl($path));
+    }
+}

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Plates;
+
+use Interop\Container\ContainerInterface;
+use League\Plates\Engine as PlatesEngine;
+use League\Plates\Extension\ExtensionInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Plates\Exception\InvalidExtensionException;
+use Zend\Expressive\Plates\Extension\UrlExtension;
+use Zend\Expressive\Plates\PlatesEngineFactory;
+
+class PlatesEngineFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        TestAsset\TestExtension::$engine = null;
+        $this->container = $this->prophesize(ContainerInterface::class);
+
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn(
+            $this->prophesize(UrlHelper::class)->reveal()
+        );
+
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn(
+            $this->prophesize(ServerUrlHelper::class)->reveal()
+        );
+
+        $this->container->has(UrlExtension::class)->willReturn(false);
+    }
+
+    public function testFactoryReturnsPlatesEngine()
+    {
+        $this->container->has('config')->willReturn(false);
+        $factory = new PlatesEngineFactory();
+        $engine = $factory($this->container->reveal());
+        $this->assertInstanceOf(PlatesEngine::class, $engine);
+        return $engine;
+    }
+
+    /**
+     * @depends testFactoryReturnsPlatesEngine
+     */
+    public function testUrlExtensionIsRegisteredByDefault($engine)
+    {
+        $this->assertTrue($engine->doesFunctionExist('url'));
+        $this->assertTrue($engine->doesFunctionExist('serverurl'));
+    }
+
+    public function testFactoryCanRegisterConfiguredExtensions()
+    {
+        $extensionOne = $this->prophesize(ExtensionInterface::class);
+        $extensionOne->register(Argument::type(PlatesEngine::class))->shouldBeCalled();
+
+        $extensionTwo = $this->prophesize(ExtensionInterface::class);
+        $extensionTwo->register(Argument::type(PlatesEngine::class))->shouldBeCalled();
+        $this->container->has('ExtensionTwo')->willReturn(true);
+        $this->container->get('ExtensionTwo')->willReturn($extensionTwo->reveal());
+
+        $this->container->has(TestAsset\TestExtension::class)->willReturn(false);
+
+        $config = [
+            'plates' => [
+                'extensions' => [
+                    $extensionOne->reveal(),
+                    'ExtensionTwo',
+                    TestAsset\TestExtension::class,
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $factory = new PlatesEngineFactory();
+        $engine = $factory($this->container->reveal());
+        $this->assertInstanceOf(PlatesEngine::class, $engine);
+
+        // Test that the TestExtension was registered. The other two extensions
+        // are verified via mocking.
+        $this->assertSame($engine, TestAsset\TestExtension::$engine);
+    }
+
+    public function invalidExtensions()
+    {
+        return [
+            'null' => [null],
+            'true' => [true],
+            'false' => [false],
+            'zero' => [0],
+            'int' => [1],
+            'zero-float' => [0.0],
+            'float' => [1.1],
+            'non-class-string' => ['not-a-class'],
+            'array' => [['not-an-extension']],
+            'non-extension-object' => [(object) ['extension' => 'not-really']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidExtensions
+     */
+    public function testFactoryRaisesExceptionForInvalidExtensions($extension)
+    {
+        $config = [
+            'plates' => [
+                'extensions' => [
+                    $extension,
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        if (is_string($extension)) {
+            $this->container->has($extension)->willReturn(false);
+        }
+
+        $factory = new PlatesEngineFactory();
+        $this->setExpectedException(InvalidExtensionException::class);
+        $factory($this->container->reveal());
+    }
+}

--- a/test/PlatesRendererTest.php
+++ b/test/PlatesRendererTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZendTest\Expressive\Template;
+namespace ZendTest\Expressive\Plates;
 
 use ArrayObject;
 use League\Plates\Engine;

--- a/test/TestAsset/TestExtension.php
+++ b/test/TestAsset/TestExtension.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Plates\TestAsset;
+
+use League\Plates\Engine;
+use League\Plates\Extension\ExtensionInterface;
+
+class TestExtension implements ExtensionInterface
+{
+    public static $engine;
+
+    public function register(Engine $engine)
+    {
+        self::$engine = $engine;
+    }
+}


### PR DESCRIPTION
This patch was prompted by a desire to have `url` and `serverurl` functions that proxy to the zend-expressive-helpers classes. In order to do that, however, I ended up needing the following as well:
- The ability to register the `League\Plates\Engine` as a service, and consume it when present.
- A factory for `League\Plates\Engine` that can load extensions into the engine (via instance, service name, or class name), as well as load the custom URL extension by default.
- The UrlExtension itself, which composes UrlHelper and ServerUrlHelper instances.
- A factory for the UrlExtension that raises exceptions if either helper is missing.

I updated the PlatesRendererFactory to delegate to the new PlatesEngineFactory if no `League\Plates\Engine` service is present in order to create the Plates engine instance. This also then ensures that by default, we have the `UrlExtension` loaded.

Because this patch provides extension loading, it supercedes the one in #6, and fixes #3.
