### PR TITLE
Add query params, fragment and reuse route result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,21 +22,22 @@
         "container-interop/container-interop": "^1.1",
         "league/plates": "^3.1",
         "zendframework/zend-expressive-template": "^1.0",
-        "zendframework/zend-expressive-helpers": "^2.0"
+        "zendframework/zend-expressive-helpers": "^3.0.0-dev",
+        "zendframework/zend-expressive-router": "^2.0.0-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
-      "psr-4": {
-        "Zend\\Expressive\\Plates\\": "src/"
-      }
+        "psr-4": {
+            "Zend\\Expressive\\Plates\\": "src/"
+        }
     },
     "autoload-dev": {
-      "psr-4": {
-        "ZendTest\\Expressive\\Plates\\": "test/"
-      }
+        "psr-4": {
+            "ZendTest\\Expressive\\Plates\\": "test/"
+        }
     },
     "suggest": {
         "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -56,13 +56,25 @@ class UrlExtension implements ExtensionInterface
     /**
      * Generate a URL from either the currently matched route or the specfied route.
      *
-     * @param null|string $route Name of route from which to generate URL.
-     * @param array $params Route substitution parameters
+     * @param string $routeName
+     * @param array  $routeParams
+     * @param array  $queryParams
+     * @param string $fragmentIdentifier
+     * @param array  $options       Can have the following keys:
+     *                              - router (array): contains options to be passed to the router
+     *                              - reuse_result_params (bool): indicates if the current RouteResult
+     *                              parameters will be used, defaults to true
+     *
      * @return string
      */
-    public function generateUrl($route = null, array $params = [])
-    {
-        return $this->urlHelper->generate($route, $params);
+    public function generateUrl(
+        $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        $fragmentIdentifier = '',
+        array $options = []
+    ) {
+        return $this->urlHelper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
     /**

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -19,7 +19,7 @@ class UrlExtensionTest extends TestCase
 {
     public function setUp()
     {
-        $this->urlHelper = $this->prophesize(UrlHelper::class);
+        $this->urlHelper       = $this->prophesize(UrlHelper::class);
         $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
 
         $this->extension = new UrlExtension(
@@ -46,9 +46,9 @@ class UrlExtensionTest extends TestCase
     public function urlHelperParams()
     {
         return [
-            'null' => [null, []],
-            'route-only' => ['route', []],
-            'params-only' => [null, ['param' => 'value']],
+            'null'             => [null, []],
+            'route-only'       => ['route', []],
+            'params-only'      => [null, ['param' => 'value']],
             'route-and-params' => ['route', ['param' => 'value']],
         ];
     }
@@ -58,14 +58,36 @@ class UrlExtensionTest extends TestCase
      */
     public function testGenerateUrlProxiesToUrlHelper($route, array $params)
     {
-        $this->urlHelper->generate($route, $params)->willReturn('/success');
+        $this->urlHelper->generate($route, $params, [], '', [])->willReturn('/success');
         $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
+    }
+
+    public function testUrlHelperAcceptsQueryParametersFragmentAndOptions()
+    {
+        $this->urlHelper->generate(
+            'resource',
+            ['id' => 'sha1'],
+            ['foo' => 'bar'],
+            'fragment',
+            ['reuse_result_params' => true]
+        )->willReturn('PATH');
+
+        $this->assertEquals(
+            'PATH',
+            $this->extension->generateUrl(
+                'resource',
+                ['id' => 'sha1'],
+                ['foo' => 'bar'],
+                'fragment',
+                ['reuse_result_params' => true]
+            )
+        );
     }
 
     public function serverUrlHelperParams()
     {
         return [
-            'null' => [null],
+            'null'          => [null],
             'absolute-path' => ['/foo/bar'],
             'relative-path' => ['foo/bar'],
         ];


### PR DESCRIPTION
This PR adds support for query parameters, fragment and a reuse route result boolean.

- [x] Requires zendframework/zend-expressive-helpers#27
- [x] Remove temp dependency to `zendframework/zend-expressive-router:^2.0.0-dev` once it is stable
- [x] Change dependency to `zendframework/zend-expressive-helpers:^3.0` once it is stable
- [x] Update (or include missing?) composer lock file