### PR TITLE
Ensure invalid extension types result in InvalidExtensionException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
     - php: 5.6
       env:
         - CS_CHECK=true
     - php: 7
+    - php: 7.1
     - php: hhvm 
   allow_failures:
     - php: hhvm

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -131,7 +131,16 @@ class PlatesEngineFactory
         }
 
         if ($container->has($extension)) {
-            $engine->loadExtension($container->get($extension));
+            $extension = $container->get($extension);
+            if (!$extension instanceof ExtensionInterface) {
+                throw new Exception\InvalidExtensionException(sprintf(
+                    '%s expects object implements %s ; received %s',
+                    __CLASS__,
+                    ExtensionInterface::class,
+                    (is_object($extension) ? get_class($extension) : gettype($extension))
+                ));
+            }
+            $engine->loadExtension($extension);
             return;
         }
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -130,29 +130,27 @@ class PlatesEngineFactory
             ));
         }
 
-        if ($container->has($extension)) {
-            $extension = $container->get($extension);
-            if (!$extension instanceof ExtensionInterface) {
-                throw new Exception\InvalidExtensionException(sprintf(
-                    '%s expects object implements %s ; received %s',
-                    __CLASS__,
-                    ExtensionInterface::class,
-                    (is_object($extension) ? get_class($extension) : gettype($extension))
-                ));
-            }
-            $engine->loadExtension($extension);
-            return;
+        if (! $container->has($extension) && ! class_exists($extension)) {
+            throw new Exception\InvalidExtensionException(sprintf(
+                '%s expects extension service names or class names; "%s" does not resolve to either',
+                __CLASS__,
+                $extension
+            ));
         }
 
-        if (class_exists($extension)) {
-            $engine->loadExtension(new $extension());
-            return;
+        $extension = $container->has($extension)
+            ? $container->get($extension)
+            : new $extension();
+
+        if (! $extension instanceof ExtensionInterface) {
+            throw new Exception\InvalidExtensionException(sprintf(
+                '%s expects extension services to implement %s ; received %s',
+                __CLASS__,
+                ExtensionInterface::class,
+                (is_object($extension) ? get_class($extension) : gettype($extension))
+            ));
         }
 
-        throw new Exception\InvalidExtensionException(sprintf(
-            '%s expects extension service names or class names; "%s" does not resolve to either',
-            __CLASS__,
-            $extension
-        ));
+        $engine->loadExtension($extension);
     }
 }

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -14,6 +14,7 @@ use League\Plates\Engine as PlatesEngine;
 use League\Plates\Extension\ExtensionInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
+use stdClass;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Plates\Exception\InvalidExtensionException;
@@ -128,6 +129,45 @@ class PlatesEngineFactoryTest extends TestCase
 
         $factory = new PlatesEngineFactory();
         $this->setExpectedException(InvalidExtensionException::class);
+        $factory($this->container->reveal());
+    }
+
+    public function testFactoryRaisesExceptionWhenAttemptingToInjectAnInvalidExtensionService()
+    {
+        $config = [
+            'plates' => [
+                'extensions' => [
+                    'FooExtension',
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $this->container->has('FooExtension')->willReturn(true);
+        $this->container->get('FooExtension')->willReturn(new stdClass());
+
+        $factory = new PlatesEngineFactory();
+        $this->setExpectedException(InvalidExtensionException::class, 'ExtensionInterface');
+        $factory($this->container->reveal());
+    }
+
+    public function testFactoryRaisesExceptionWhenNonServiceClassIsAnInvalidExtension()
+    {
+        $config = [
+            'plates' => [
+                'extensions' => [
+                    stdClass::class,
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $this->container->has(stdClass::class)->willReturn(false);
+
+        $factory = new PlatesEngineFactory();
+        $this->setExpectedException(InvalidExtensionException::class, 'ExtensionInterface');
         $factory($this->container->reveal());
     }
 }


### PR DESCRIPTION
This patch extends on #9, adding tests, and a further check for invalid non-service extension class names.

At this point, an `InvalidExtensionException` is raised if:

- a non-string extension name is encountered.
- the extension resolves to a class instance that does not fulfill `ExtensionInterface`, whether that instance is pulled from the container or instantiated directly.