### PR TITLE
Hotfix - import correct Exception namespace

### DIFF
--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -11,8 +11,8 @@ namespace Zend\Expressive\Plates;
 
 use League\Plates\Engine;
 use ReflectionProperty;
-use Zend\Expressive\Exception;
 use Zend\Expressive\Template\ArrayParametersTrait;
+use Zend\Expressive\Template\Exception;
 use Zend\Expressive\Template\TemplatePath;
 use Zend\Expressive\Template\TemplateRendererInterface;
 


### PR DESCRIPTION
Import correct Exception namespace.

This repository is not using `zend-expressive` so `Zend\Expressive\Exception` is not defined here.
Instead we should use expection from namespace `Zend\Expressive\Template\Exception`, IMHO.

Exceptions (`InvalidArgumentException`) are thrown in lines 105 and 112.