### PR TITLE
Fix fragmentIdentifier default value

### DIFF
--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -68,7 +68,7 @@ class UrlExtension implements ExtensionInterface
         $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = '',
+        $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->urlHelper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -67,7 +67,7 @@ class UrlExtensionTest extends TestCase
      */
     public function testGenerateUrlProxiesToUrlHelper($route, array $params)
     {
-        $this->urlHelper->generate($route, $params, [], '', [])->willReturn('/success');
+        $this->urlHelper->generate($route, $params, [], null, [])->willReturn('/success');
         $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
     }
 


### PR DESCRIPTION
Found this while upgrading my zend expressive application to v2.

Related: https://github.com/zendframework/zend-expressive-helpers/pull/34