### PR TITLE
Made UrlExtension not to be registered if either one of the helpers is not registered

### DIFF
--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -10,6 +10,7 @@ namespace Zend\Expressive\Plates;
 use Interop\Container\ContainerInterface;
 use League\Plates\Engine as PlatesEngine;
 use League\Plates\Extension\ExtensionInterface;
+use Zend\Expressive\Helper;
 
 /**
  * Create and return a Plates engine instance.
@@ -72,6 +73,11 @@ class PlatesEngineFactory
     {
         if ($container->has(Extension\UrlExtension::class)) {
             $engine->loadExtension($container->get(Extension\UrlExtension::class));
+            return;
+        }
+
+        // If the extension was not explicitly registered, load it only if both helpers were registered
+        if (! $container->has(Helper\UrlHelper::class) || ! $container->has(Helper\ServerUrlHelper::class)) {
             return;
         }
 

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -178,4 +178,32 @@ class PlatesEngineFactoryTest extends TestCase
         $this->expectExceptionMessage('ExtensionInterface');
         $factory($this->container->reveal());
     }
+
+    public function provideHelpersToUnregister()
+    {
+        return [
+            'url-only' => [[UrlHelper::class]],
+            'server-url-only' => [[ServerUrlHelper::class]],
+            'both' => [[ServerUrlHelper::class, UrlHelper::class]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideHelpersToUnregister
+     *
+     * @param array $helpers
+     */
+    public function testUrlExtensionIsNotLoadedIfHelpersAreNotRegistered(array $helpers)
+    {
+        $this->container->has('config')->willReturn(false);
+        foreach ($helpers as $helper) {
+            $this->container->has($helper)->willReturn(false);
+        }
+
+        $factory = new PlatesEngineFactory();
+        $engine = $factory($this->container->reveal());
+
+        $this->assertFalse($engine->doesFunctionExist('url'));
+        $this->assertFalse($engine->doesFunctionExist('serverurl'));
+    }
 }


### PR DESCRIPTION
This fixes #24 

I have made the `UrlExtension` not to be loaded on plates engine when either the `UrlHelper` or the `ServerUrlHelper` are not registered in the container.

This way, if you don't need them, you don't have to depend on the [zendframework/zend-expressive-helpers](https://github.com/zendframework/zend-expressive-helpers) package.

I have selected an approach in which the check is not performed if you have explicitly registered the `UrlExtension` in the container. In that case, an exception will still be thrown if you didn't register the helpers yourself.