### PR TITLE
Docs and Travis CI updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/docs export-ignore
 /test export-ignore
 .coveralls.yml
 .gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
-/docs export-ignore
-/test export-ignore
 /.coveralls.yml export-ignore
 /.docheader export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /composer.lock export-ignore
+/docs/ export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
+/test/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
 /docs export-ignore
 /test export-ignore
-.coveralls.yml
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-phpcs.xml export-ignore
-phpunit.xml.dist export-ignore
+/.coveralls.yml export-ignore
+/.docheader export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-vendor/
-clover.xml
-coveralls-upload.json
-phpunit.xml
+/clover.xml
+/coveralls-upload.json
+/phpunit.xml
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
-phpunit.xml
 clover.xml
 coveralls-upload.json
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   include:
@@ -20,38 +19,45 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
+    - php: 5.6
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7
+      env:
+        - DEPS=lowest
+    - php: 7
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
+    - php: 7
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
+    - php: 7
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
         - CS_CHECK=true
         - TEST_COVERAGE=true
-        - HELPERS_DEP="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 5.6
-      env:
-        - DEPS=locked
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-    - php: 7
-      env:
-        - DEPS=locked
-        - HELPERS_DEP="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=locked
-    - php: 7.1
-      env:
-        - DEPS=locked
-        - HELPERS_DEP="zendframework/zend-expressive-helpers:^3.0.1"
     - php: 7.1
       env:
         - DEPS=latest
@@ -61,26 +67,24 @@ matrix:
     - php: 7.2
       env:
         - DEPS=locked
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
     - php: 7.2
       env:
         - DEPS=locked
-        - HELPERS_DEP="zendframework/zend-expressive-helpers:^3.0.1"
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $HELPERS_DEP != '' ]]; then travis_retry composer require $COMPOSER_ARGS --update-with-dependencies $HELPERS_DEP ; fi
+  - if [[ $HELPER_DEPS != '' ]]; then travis_retry composer require $COMPOSER_ARGS --update-with-dependencies $HELPER_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
       env:
         - DEPS=locked
         - LEGACY_DEPS="phpunit/phpunit"
+    - php: 5.6
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
         - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
     - php: 5.6
       env:
@@ -36,6 +40,10 @@ matrix:
       env:
         - DEPS=locked
         - LEGACY_DEPS="phpunit/phpunit"
+    - php: 7
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
         - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
     - php: 7
       env:
@@ -51,19 +59,25 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 7.1
-      env:
-        - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
         - CS_CHECK=true
         - TEST_COVERAGE=true
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
     - php: 7.1
       env:
         - DEPS=latest
     - php: 7.2
       env:
         - DEPS=lowest
+    - php: 7.2
+      env:
+        - DEPS=locked
     - php: 7.2
       env:
         - DEPS=locked

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,12 +5,12 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-- Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
 
 - Neither the name of Zend Technologies USA, Inc. nor the names of its
   contributors may be used to endorse or promote products derived from this

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,4 @@
 Copyright (c) 2015-2017, Zend Technologies USA, Inc.
-
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Plates Integration for Expressive
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-expressive-platesrenderer.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-expressive-platesrenderer)
-[![Coverage Status](https://coveralls.io/repos/zendframework/zend-expressive-platesrenderer/badge.svg?branch=master)](https://coveralls.io/r/zendframework/zend-expressive-platesrenderer?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/zendframework/zend-expressive-platesrenderer/badge.svg?branch=master)](https://coveralls.io/github/zendframework/zend-expressive-platesrenderer?branch=master)
 
 Provides integration with [Plates](http://platesphp.com/) for
 [Expressive](https://github.com/zendframework/zend-expressive).

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,6 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v",
-        "license-check": "vendor/bin/docheader check src/ test/"
+        "license-check": "docheader check src/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,6 @@
         "zendframework",
         "zend-expressive"
     ],
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.4-dev",
-            "dev-develop": "1.5-dev"
-        }
-    },
     "support": {
         "issues": "https://github.com/zendframework/zend-expressive-platesrenderer/issues",
         "source": "https://github.com/zendframework/zend-expressive-platesrenderer",
@@ -47,6 +38,11 @@
     "conflict": {
         "container-interop/container-interop": "<1.2.0"
     },
+    "suggest": {
+        "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
+        "aura/di": "^3.2 to make use of Aura.Di dependency injection container",
+        "zendframework/zend-servicemanager": "^3.2 to use zend-servicemanager for dependency injection"
+    },
     "autoload": {
         "psr-4": {
             "Zend\\Expressive\\Plates\\": "src/"
@@ -57,10 +53,14 @@
             "ZendTest\\Expressive\\Plates\\": "test/"
         }
     },
-    "suggest": {
-        "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
-        "aura/di": "^3.2 to make use of Aura.Di dependency injection container",
-        "zendframework/zend-servicemanager": "^3.2 to use zend-servicemanager for dependency injection"
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.4-dev",
+            "dev-develop": "1.5-dev"
+        }
     },
     "scripts": {
         "check": [
@@ -73,6 +73,6 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v",
-        "license-check": "docheader check src/"
+        "license-check": "docheader check src/ test/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "zendframework/zend-expressive-platesrenderer",
     "description": "Plates integration for Expressive",
-    "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
         "expressive",
@@ -9,13 +8,26 @@
         "league",
         "plates",
         "psr",
-        "psr-7"
+        "psr-7",
+        "zf",
+        "zendframework",
+        "zend-expressive"
     ],
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.4-dev",
             "dev-develop": "1.5-dev"
         }
+    },
+    "support": {
+        "issues": "https://github.com/zendframework/zend-expressive-platesrenderer/issues",
+        "source": "https://github.com/zendframework/zend-expressive-platesrenderer",
+        "rss": "https://github.com/zendframework/zend-expressive-platesrenderer/releases.atom",
+        "slack": "https://zendframework-slack.herokuapp.com",
+        "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
     "require": {
         "php": "^5.6 || ^7.0",
@@ -29,7 +41,7 @@
     "require-dev": {
         "http-interop/http-middleware": "0.4.1",
         "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+        "phpunit/phpunit": "^5.7.23 || ^6.4.3",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "conflict": {
@@ -56,11 +68,11 @@
             "@cs-check",
             "@test"
         ],
-        "upload-coverage": "coveralls -v",
-        "cs-check": "phpcs --colors",
-        "cs-fix": "phpcbf --colors",
-        "license-check": "docheader check src/",
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --coverage-clover clover.xml"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "upload-coverage": "coveralls -v",
+        "license-check": "vendor/bin/docheader check src/ test/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,6 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v",
-        "license-check": "docheader check src/ test/"
+        "license-check": "docheader check src/"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "13d9ffad317c6cdb47390cadde7ac887",
+    "content-hash": "266c4e0e25974837dc7c5c61bc9f03d3",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -566,32 +566,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -616,7 +616,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -1512,30 +1512,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
                 "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1566,13 +1566,13 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "time": "2017-11-03T07:16:52+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Code of Conduct
 
-The Zend Framework project adheres to [The Code Manifesto](http://codemanifesto.com)
+This project adheres to [The Code Manifesto](http://codemanifesto.com)
 as its guidelines for contributor interactions.
 
 ## The Code Manifesto

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,37 +2,16 @@
 
 ## RESOURCES
 
-If you wish to contribute to Zend Framework, please be sure to
+If you wish to contribute to this project, please be sure to
 read/subscribe to the following resources:
 
- -  [Coding Standards](https://github.com/zendframework/zf2/wiki/Coding-Standards)
- -  [Contributor's Guide](CONTRIBUTING.md)
- -  ZF Contributor's mailing list:
-    Archives: http://zend-framework-community.634137.n4.nabble.com/ZF-Contributor-f680267.html
-    Subscribe: zf-contributors-subscribe@lists.zend.com
- -  ZF Contributor's IRC channel:
-    #zftalk.dev on Freenode.net
+ - [Coding Standards](https://github.com/zendframework/zend-coding-standard)
+ - [Forums](https://discourse.zendframework.com/c/contributors)
+ - [Slack](https://zendframework-slack.herokuapp.com)
+ - [Code of Conduct](CODE_OF_CONDUCT.md)
 
-If you are working on new features or refactoring [create a proposal](https://github.com/zendframework/zend-expressive-platesrenderer/issues/new).
-
-## Reporting Potential Security Issues
-
-If you have encountered a potential security vulnerability, please **DO NOT** report it on the public
-issue tracker: send it to us at [zf-security@zend.com](mailto:zf-security@zend.com) instead.
-We will work with you to verify the vulnerability and patch it as soon as possible.
-
-When reporting issues, please provide the following information:
-
-- Component(s) affected
-- A description indicating how to reproduce the issue
-- A summary of the security vulnerability and impact
-
-We request that you contact us via the email address above and give the project
-contributors a chance to resolve the vulnerability and issue a new release prior
-to any public exposure; this helps protect users and provides them with a chance
-to upgrade and/or update in order to protect their applications.
-
-For sensitive email communications, please use [our PGP key](http://framework.zend.com/zf-security-pgp-key.asc).
+If you are working on new features or refactoring
+[create a proposal](https://github.com/zendframework/zend-expressive-platesrenderer/issues/new).
 
 ## RUNNING TESTS
 
@@ -85,18 +64,6 @@ $ composer cs-fix
 
 If the above fixes any CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
-
-## Running License Checks
-
-File-level docblocks should follow the format demonstrated in `.docheader`. To
-check for conformity, use:
-
-```console
-$ composer license-check
-```
-
-This will flag files that are incorrect, which you can then update. Re-run the
-tool to verify your changes.
 
 ## Recommended Workflow for Contributions
 
@@ -189,15 +156,7 @@ To send a pull request, you have two options.
 If using GitHub, you can do the pull request from there. Navigate to
 your repository, select the branch you just created, and then select the
 "Pull Request" button in the upper right. Select the user/organization
-"zendframework" as the recipient.
-
-If using your own repository - or even if using GitHub - you can use `git
-format-patch` to create a patchset for us to apply; in fact, this is
-**recommended** for security-related patches. If you use `format-patch`, please
-send the patches as attachments to:
-
--  zf-devteam@zend.com for patches without security implications
--  zf-security@zend.com for security patches
+"zendframework" (or whatever the upstream organization is) as the recipient.
 
 #### What branch to issue the pull request against?
 
@@ -228,8 +187,3 @@ repository, we suggest doing some cleanup of these branches.
    ```console
    $ git push {username} :<branchname>
    ```
-
-
-## Conduct
-
-Please see our [CONDUCT.md](CONDUCT.md) to understand expected behavior when interacting with others in the project.

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Provide a narrative description of the issue.
+
+### Code to reproduce the issue
+
+```php
+```
+
+### Expected results
+
+### Actual results
+

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,11 +1,19 @@
-Provide a narrative description of the issue.
+ - [ ] I was not able to find an [open](https://github.com/zendframework/zend-expressive-platesrenderer/issues?q=is%3Aopen) or [closed](https://github.com/zendframework/zend-expressive-platesrenderer/issues?q=is%3Aclosed) issue matching what I'm seeing.
+ - [ ] This is not a question. (Questions should be asked on [slack](https://zendframework.slack.com/) ([Signup for Slack here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
+
+Provide a narrative description of what you are trying to accomplish.
 
 ### Code to reproduce the issue
+
+<!-- Please provide the minimum code necessary to recreate the issue -->
 
 ```php
 ```
 
 ### Expected results
 
+<!-- What do you think should have happened? -->
+
 ### Actual results
 
+<!-- What did you actually observe? -->

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+Provide a narrative description of what you are trying to accomplish:
+
+- [ ] Are you fixing a bug?
+  - [ ] Detail how the bug is invoked currently.
+  - [ ] Detail the original, incorrect behavior.
+  - [ ] Detail the new, expected behavior.
+  - [ ] Base your feature on the `master` branch, and submit against that branch.
+  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
+  - [ ] Add a `CHANGELOG.md` entry for the fix.
+
+- [ ] Are you creating a new feature?
+  - [ ] Why is the new feature needed? What purpose does it serve?
+  - [ ] How will users use the new feature?
+  - [ ] Base your feature on the `develop` branch, and submit against that branch.
+  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
+  - [ ] Add tests for the new feature.
+  - [ ] Add documentation for the new feature.
+  - [ ] Add a `CHANGELOG.md` entry for the new feature.
+
+- [ ] Is this related to quality assurance?
+  - [ ] Detail why the changes are necessary.
+
+- [ ] Is this related to documentation?
+  - [ ] Is it a typographical and/or grammatical fix?
+  - [ ] Is it new documentation?

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,8 @@ Provide a narrative description of what you are trying to accomplish:
   - [ ] Add a `CHANGELOG.md` entry for the new feature.
 
 - [ ] Is this related to quality assurance?
-  - [ ] Detail why the changes are necessary.
+  <!-- Detail why the changes are necessary -->
 
 - [ ] Is this related to documentation?
-  - [ ] Is it a typographical and/or grammatical fix?
-  - [ ] Is it new documentation?
+  <!-- Is it a typographical and/or grammatical fix? -->
+  <!-- Is it new documentation? -->

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,25 @@
+# Getting Support
+
+Zend Framework offers three support channels:
+
+- For real-time questions, use our
+  [Slack](https://zendframework-slack.herokuapp.com)
+- For detailed questions (e.g., those requiring examples) use our
+  [forums](https://discourse.zendframework.com/c/questions/expressive)
+- To report issues, use this repository's
+  [issue tracker](https://github.com/zendframework/zend-expressive-platesrenderer/issues/new)
+
+**DO NOT** use the issue tracker to ask questions; use Slack or the forums for
+that. Questions posed to the issue tracker will be closed.
+
+When reporting an issue, please include the following details:
+
+- A narrative description of what you are trying to accomplish.
+- The minimum code necessary to reproduce the issue.
+- The expected results of exercising that code.
+- The actual results received.
+
+We may ask for additional details: what version of the library you are using,
+and what PHP version was used to reproduce the issue.
+
+You may also submit a failing test case as a pull request.

--- a/test/Extension/EscaperExtensionTest.php
+++ b/test/Extension/EscaperExtensionTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
+ */
 
 namespace ZendTest\Expressive\Plates\Extension;
 


### PR DESCRIPTION
- updated `.gitattributes` and `.gitignore`
- updated Travis CI configuration:
  - updated legacy dependencies
  - testing with all supported version of `zend-expressive-helpers` (as it is in other repos)
  - removed `composer self-update`
  - moved cs-check and coverage to run on PHP 7.2 with locked deps
- all support files in `docs` directory - added missing files and updated existing
- updated `composer.json`
