### PR TITLE
PSR-15 support (No BC Break)

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,7 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,46 +13,6 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
-    - php: 7
-      env:
-        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest
@@ -64,11 +24,9 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
     - php: 7.1
       env:
         - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
     - php: 7.1
       env:
         - DEPS=latest
@@ -81,11 +39,9 @@ matrix:
     - php: 7.2
       env:
         - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^2.2 zendframework/zend-expressive-router:^1.3.2"
     - php: 7.2
       env:
         - DEPS=locked
-        - HELPER_DEPS="zendframework/zend-expressive-helpers:^3.0.1"
     - php: 7.2
       env:
         - DEPS=latest
@@ -95,10 +51,8 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $HELPER_DEPS != '' ]]; then travis_retry composer require $COMPOSER_ARGS --update-with-dependencies $HELPER_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,10 @@ matrix:
         - TEST_COVERAGE=true
     - php: 7.1
       env:
-        - DEPS=locked
-    - php: 7.1
-      env:
-        - DEPS=locked
-    - php: 7.1
-      env:
         - DEPS=latest
     - php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=locked
-    - php: 7.2
-      env:
-        - DEPS=locked
     - php: 7.2
       env:
         - DEPS=locked

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "zendframework/zend-escaper": "^2.5"
     },
     "require-dev": {
-        "http-interop/http-middleware": "0.4.1",
         "malukenho/docheader": "^0.1.5",
         "phpunit/phpunit": "^6.0.8 || ^5.7.15",
         "zendframework/zend-coding-standard": "~1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+        "phpunit/phpunit": "^6.5.3",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,22 @@
             "dev-develop": "1.5-dev"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-helpers.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        }
+    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "league/plates": "^3.3",
         "psr/container": "^1.0",
-        "zendframework/zend-expressive-helpers": "^2.2 || ^3.0.1 || ^4.0",
-        "zendframework/zend-expressive-router": "^1.3.2 || ^2.1",
+        "zendframework/zend-expressive-helpers": "dev-feature/psr-15",
+        "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
         "zendframework/zend-expressive-template": "^1.0.4",
         "zendframework/zend-escaper": "^2.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "13d9ffad317c6cdb47390cadde7ac887",
+    "content-hash": "69460eca8a9abe4378f950ed1bd6a929",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -58,16 +58,16 @@
         },
         {
             "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +82,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,16 +97,16 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
-            "time": "2017-01-14T15:23:42+00:00"
+            "abandoned": "http-interop/http-server-middleware",
+            "time": "2017-09-18T15:27:03+00:00"
         },
         {
             "name": "league/plates",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa6154cfbd947749364ca50547eaaa82",
+    "content-hash": "63a005024c48622ee9aecdcf9c9abad7",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "69460eca8a9abe4378f950ed1bd6a929",
+    "content-hash": "c1a85fcfcb3d87c48a894afcb782ac44",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -57,22 +57,78 @@
             "time": "2017-02-09T16:10:21+00:00"
         },
         {
-            "name": "http-interop/http-middleware",
-            "version": "0.5.0",
+            "name": "http-interop/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
+                "url": "https://github.com/http-interop/http-server-handler.git",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
+                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": ">=7.0",
                 "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2017-11-09T18:35:22+00:00"
+        },
+        {
+            "name": "http-interop/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-server-middleware.git",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-server-handler": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "replace": {
+                "http-interop/http-middleware": ">=0.5"
             },
             "type": "library",
             "extra": {
@@ -105,8 +161,7 @@
                 "request",
                 "response"
             ],
-            "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-09-18T15:27:03+00:00"
+            "time": "2017-11-09T21:42:30+00:00"
         },
         {
             "name": "league/plates",
@@ -263,98 +318,6 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.5.2",
-                "mikey179/vfsstream": "^1.6.5",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webimpress\\ComposerExtraDependency\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Composer plugin to require extra dependencies",
-            "homepage": "https://github.com/webimpress/composer-extra-dependency",
-            "keywords": [
-                "composer",
-                "dependency",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:15:14+00:00"
-        },
-        {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "shasum": ""
-            },
-            "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
-            },
-            "type": "library",
-            "extra": {
-                "dependency": [
-                    "http-interop/http-middleware"
-                ]
-            },
-            "autoload": {
-                "files": [
-                    "autoload/http-middleware.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
-            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
-            "keywords": [
-                "middleware",
-                "psr-15",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:31:10+00:00"
-        },
-        {
             "name": "zendframework/zend-escaper",
             "version": "2.5.2",
             "source": {
@@ -400,29 +363,23 @@
         },
         {
             "name": "zendframework/zend-expressive-helpers",
-            "version": "4.2.0",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-helpers.git",
-                "reference": "137d863d4741210d05297b4bb1c30264f100ba8f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-helpers/zipball/137d863d4741210d05297b4bb1c30264f100ba8f",
-                "reference": "137d863d4741210d05297b4bb1c30264f100ba8f",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-helpers.git",
+                "reference": "0b6e0b9335a4aaa00711b2a30584f156dc2ac223"
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1",
                 "zendframework/zend-expressive-router": "^2.2"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
                 "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.3.10"
             },
@@ -443,7 +400,36 @@
                     "Zend\\Expressive\\Helper\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Helper\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -455,31 +441,25 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-10-09T19:03:01+00:00"
+            "time": "2017-11-15T22:28:11+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "62b11753700ec6c15766412d72dbe11d6fe9c60d"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -499,7 +479,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -511,7 +520,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "time": "2017-11-15T22:36:23+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -2454,9 +2463,19 @@
             "time": "2016-11-09T21:30:43+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-expressive-router"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-helpers": 20,
+        "zendframework/zend-expressive-router": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Exception;
 

--- a/src/Exception/InvalidExtensionException.php
+++ b/src/Exception/InvalidExtensionException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Exception;
 

--- a/src/Exception/MissingHelperException.php
+++ b/src/Exception/MissingHelperException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Exception;
 

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -23,11 +23,8 @@ class EscaperExtension implements ExtensionInterface
 
     /**
      * EscaperExtension constructor.
-     *
-     * @param null|string $encoding
-     * @throws InvalidArgumentException
      */
-    public function __construct($encoding = null)
+    public function __construct(string $encoding = null)
     {
         $this->escaper = new Escaper($encoding);
     }
@@ -46,7 +43,7 @@ class EscaperExtension implements ExtensionInterface
      * @param Engine $engine
      * @return void
      */
-    public function register(Engine $engine)
+    public function register(Engine $engine) : void
     {
         $engine->registerFunction('escapeHtml', [$this->escaper, 'escapeHtml']);
         $engine->registerFunction('escapeHtmlAttr', [$this->escaper, 'escapeHtmlAttr']);

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Extension;
 

--- a/src/Extension/EscaperExtensionFactory.php
+++ b/src/Extension/EscaperExtensionFactory.php
@@ -27,11 +27,9 @@ use Zend\Escaper\Exception\InvalidArgumentException;
 class EscaperExtensionFactory
 {
     /**
-     * @param ContainerInterface $container
-     * @return EscaperExtension
      * @throws InvalidArgumentException
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : EscaperExtension
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['plates']) ? $config['plates'] : [];

--- a/src/Extension/EscaperExtensionFactory.php
+++ b/src/Extension/EscaperExtensionFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Extension;
 

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Extension;
 

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -43,11 +43,8 @@ class UrlExtension implements ExtensionInterface
      *
      * - url($route = null, array $params = []) : string
      * - serverurl($path = null) : string
-     *
-     * @param Engine $engine
-     * @return void
      */
-    public function register(Engine $engine)
+    public function register(Engine $engine) : void
     {
         $engine->registerFunction('url', [$this, 'generateUrl']);
         $engine->registerFunction('serverurl', [$this, 'generateServerUrl']);
@@ -56,10 +53,6 @@ class UrlExtension implements ExtensionInterface
     /**
      * Generate a URL from either the currently matched route or the specfied route.
      *
-     * @param string $routeName
-     * @param array  $routeParams
-     * @param array  $queryParams
-     * @param string $fragmentIdentifier
      * @param array  $options Can have the following keys:
      *     - router (array): contains options to be passed to the router
      *     - reuse_result_params (bool): indicates if the current RouteResult
@@ -67,10 +60,10 @@ class UrlExtension implements ExtensionInterface
      * @return string
      */
     public function generateUrl(
-        $routeName = null,
+        string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->urlHelper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
@@ -78,11 +71,8 @@ class UrlExtension implements ExtensionInterface
 
     /**
      * Generate a fully qualified URI, relative to $path.
-     *
-     * @param null|string $path
-     * @return string
      */
-    public function generateServerUrl($path = null)
+    public function generateServerUrl(string $path = null) : string
     {
         return $this->serverUrlHelper->generate($path);
     }

--- a/src/Extension/UrlExtensionFactory.php
+++ b/src/Extension/UrlExtensionFactory.php
@@ -20,12 +20,10 @@ use Zend\Expressive\Plates\Exception\MissingHelperException;
 class UrlExtensionFactory
 {
     /**
-     * @param ContainerInterface $container
-     * @return UrlExtension
      * @throws MissingHelperException if UrlHelper service is missing.
      * @throws MissingHelperException if ServerUrlHelper service is missing.
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : UrlExtension
     {
         if (! $container->has(UrlHelper::class)) {
             throw new MissingHelperException(sprintf(

--- a/src/Extension/UrlExtensionFactory.php
+++ b/src/Extension/UrlExtensionFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates\Extension;
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates;
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -38,11 +38,7 @@ use Zend\Expressive\Helper;
  */
 class PlatesEngineFactory
 {
-    /**
-     * @param ContainerInterface $container
-     * @return PlatesEngine
-     */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : PlatesEngine
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['plates']) ? $config['plates'] : [];
@@ -68,12 +64,8 @@ class PlatesEngineFactory
      *
      * Otherwise, instantiates the UrlExtensionFactory, and invokes it with
      * the container, loading the result into the engine.
-     *
-     * @param ContainerInterface $container
-     * @param PlatesEngine $engine
-     * @return void
      */
-    private function injectUrlExtension(ContainerInterface $container, PlatesEngine $engine)
+    private function injectUrlExtension(ContainerInterface $container, PlatesEngine $engine) : void
     {
         if ($container->has(Extension\UrlExtension::class)) {
             $engine->loadExtension($container->get(Extension\UrlExtension::class));
@@ -97,12 +89,8 @@ class PlatesEngineFactory
      *
      * Otherwise, instantiates the EscaperExtensionFactory, and invokes it with
      * the container, loading the result into the engine.
-     *
-     * @param ContainerInterface $container
-     * @param PlatesEngine $engine
-     * @return void
      */
-    private function injectEscaperExtension(ContainerInterface $container, PlatesEngine $engine)
+    private function injectEscaperExtension(ContainerInterface $container, PlatesEngine $engine) : void
     {
         if ($container->has(Extension\EscaperExtension::class)) {
             $engine->loadExtension($container->get(Extension\EscaperExtension::class));
@@ -115,12 +103,8 @@ class PlatesEngineFactory
 
     /**
      * Inject all configured extensions into the engine.
-     * @param ContainerInterface $container
-     * @param PlatesEngine $engine
-     * @param array $extensions
-     * @return void
      */
-    private function injectExtensions(ContainerInterface $container, PlatesEngine $engine, array $extensions)
+    private function injectExtensions(ContainerInterface $container, PlatesEngine $engine, array $extensions) : void
     {
         foreach ($extensions as $extension) {
             $this->injectExtension($container, $engine, $extension);
@@ -138,16 +122,13 @@ class PlatesEngineFactory
      *
      * If anything else is provided, an exception is raised.
      *
-     * @param ContainerInterface $container
-     * @param PlatesEngine $engine
      * @param ExtensionInterface|string $extension
-     * @return void
      * @throws Exception\InvalidExtensionException for non-string,
      *     non-extension $extension values.
      * @throws Exception\InvalidExtensionException for string $extension values
      *     that do not resolve to an extension instance.
      */
-    private function injectExtension(ContainerInterface $container, PlatesEngine $engine, $extension)
+    private function injectExtension(ContainerInterface $container, PlatesEngine $engine, $extension) : void
     {
         if ($extension instanceof ExtensionInterface) {
             $engine->loadExtension($extension);

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates;
 
@@ -35,13 +37,9 @@ class PlatesRenderer implements TemplateRendererInterface
     }
 
     /**
-     * Render
-     *
-     * @param string $name
-     * @param array|object $params
-     * @return string
+     * {@inheritDoc}
      */
-    public function render($name, $params = [])
+    public function render(string $name, $params = []) : string
     {
         $params = $this->normalizeParams($params);
         return $this->template->render($name, $params);
@@ -54,12 +52,8 @@ class PlatesRenderer implements TemplateRendererInterface
      * E_USER_WARNING and act as a no-op. Plates does not handle non-namespaced
      * folders, only the default directory; overwriting the default directory
      * is likely unintended.
-     *
-     * @param string $path
-     * @param string $namespace
-     * @return void
      */
-    public function addPath($path, $namespace = null)
+    public function addPath(string $path, string $namespace = null) : void
     {
         if (! $namespace && ! $this->template->getDirectory()) {
             $this->template->setDirectory($path);
@@ -75,11 +69,9 @@ class PlatesRenderer implements TemplateRendererInterface
     }
 
     /**
-     * Get the template directories
-     *
-     * @return TemplatePath[]
+     * {@inheritDoc}
      */
-    public function getPaths()
+    public function getPaths() : array
     {
         $paths = $this->template->getDirectory()
             ? [ $this->getDefaultPath() ]
@@ -96,7 +88,7 @@ class PlatesRenderer implements TemplateRendererInterface
      *
      * {@inheritDoc}
      */
-    public function addDefaultParam($templateName, $param, $value)
+    public function addDefaultParam(string $templateName, string $param, $value) : void
     {
         if (! is_string($templateName) || empty($templateName)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -124,21 +116,16 @@ class PlatesRenderer implements TemplateRendererInterface
 
     /**
      * Create a default Plates engine
-     *
-     * @params string $path
-     * @return Engine
      */
-    private function createTemplate()
+    private function createTemplate() : Engine
     {
         return new Engine();
     }
 
     /**
      * Create and return a TemplatePath representing the default Plates directory.
-     *
-     * @return TemplatePath
      */
-    private function getDefaultPath()
+    private function getDefaultPath() : TemplatePath
     {
         return new TemplatePath($this->template->getDirectory());
     }
@@ -148,7 +135,7 @@ class PlatesRenderer implements TemplateRendererInterface
      *
      * @return \League\Plates\Template\Folder[]
      */
-    private function getPlatesFolders()
+    private function getPlatesFolders() : array
     {
         $folders = $this->template->getFolders();
         $r = new ReflectionProperty($folders, 'folders');

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Plates;
 

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -36,11 +36,7 @@ use League\Plates\Engine as PlatesEngine;
  */
 class PlatesRendererFactory
 {
-    /**
-     * @param ContainerInterface $container
-     * @return PlatesRenderer
-     */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : PlatesRenderer
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['templates']) ? $config['templates'] : [];
@@ -75,11 +71,8 @@ class PlatesRendererFactory
      *
      * Otherwise, invokes the PlatesEngineFactory with the $container to create
      * and return the instance.
-     *
-     * @param ContainerInterface $container
-     * @return PlatesEngine
      */
-    private function createEngine(ContainerInterface $container)
+    private function createEngine(ContainerInterface $container) : PlatesEngine
     {
         if ($container->has(PlatesEngine::class)) {
             return $container->get(PlatesEngine::class);

--- a/test/Extension/EscaperExtensionFactoryTest.php
+++ b/test/Extension/EscaperExtensionFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates\Extension;
 

--- a/test/Extension/EscaperExtensionTest.php
+++ b/test/Extension/EscaperExtensionTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates\Extension;
 

--- a/test/Extension/UrlExtensionFactoryTest.php
+++ b/test/Extension/UrlExtensionFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates\Extension;
 

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates\Extension;
 

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates;
 

--- a/test/PlatesRendererFactoryTest.php
+++ b/test/PlatesRendererFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates;
 

--- a/test/PlatesRendererTest.php
+++ b/test/PlatesRendererTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates;
 
@@ -46,7 +48,10 @@ class PlatesRendererTest extends TestCase
 
     public function assertTemplatePathNamespace($namespace, TemplatePath $templatePath, $message = null)
     {
-        $message = $message ?: sprintf('Failed to assert TemplatePath namespace matched %s', var_export($namespace, 1));
+        $message = $message ?: sprintf(
+            'Failed to assert TemplatePath namespace matched %s',
+            var_export($namespace, true)
+        );
         $this->assertEquals($namespace, $templatePath->getNamespace(), $message);
     }
 

--- a/test/TestAsset/TestExtension.php
+++ b/test/TestAsset/TestExtension.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-platesrenderer for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-platesrenderer/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Plates\TestAsset;
 


### PR DESCRIPTION
This is no BC Break (as long as I can see) because requirements of http-interop/http-middleware in require-dev section was not used and.
I've updated `zend-expressive-helpers` and `zend-expressive-router` dependencies to my PR with PSR-15 support to check if all tests pass here.

I think it will be able to add new new released version of these components and all should be fine.

Requires:
- [x] https://github.com/zendframework/zend-expressive-helpers/pull/50
- [x] https://github.com/zendframework/zend-expressive-router/pull/39