### PR TITLE
remove redundant functions/nested calls/tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.2.0 - TBD
+## 2.2.0 - 2019-10-08
 
 ### Added
 
@@ -10,33 +10,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#37](https://github.com/zendframework/zend-expressive-platesrenderer/pull/37) changes some internal logic in how the UrlHelper and ServerUrlHelper are exposed as Plates functions, reducing the number of nested calls and improving performance.
 
 ### Deprecated
 
-- Nothing.
+- [#37](https://github.com/zendframework/zend-expressive-platesrenderer/pull/37) deprecates the method `Zend\Expressive\Plates\Extension\UrlExtension::generateServerUrl()`. Originally, the extension registered this method with the Plates engine as the function `serverurl()`; we now register the `Zend\Expressive\Helper\ServerUrlHelper` instance directly (as it is callable), making the method obsolete. It will be removed in version 3.0.0.
 
-### Removed
+- [#37](https://github.com/zendframework/zend-expressive-platesrenderer/pull/37) deprecates the method `Zend\Expressive\Plates\Extension\UrlExtension::generateUrl()`. Originally, the extension registered this method with the Plates engine as the function `url()`; we now register the `Zend\Expressive\Helper\UrlHelper` instance directly (as it is callable), making the method obsolete. It will be removed in version 3.0.0.
 
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
-## 2.1.1 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
+- [#37](https://github.com/zendframework/zend-expressive-platesrenderer/pull/37) deprecates the method `Zend\Expressive\Plates\Extension\UrlExtension::getRouteResult()`. Originally, the extension registered this method with the Plates engine as the function `route()`; we now register the `Zend\Expressive\Helper\UrlHelper::getRouteResult()` method directly, making the method obsolete. It will be removed in version 3.0.0.
 
 ### Removed
 

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -47,43 +47,8 @@ class UrlExtension implements ExtensionInterface
      */
     public function register(Engine $engine) : void
     {
-        $engine->registerFunction('url', [$this, 'generateUrl']);
-        $engine->registerFunction('serverurl', [$this, 'generateServerUrl']);
-        $engine->registerFunction('route', [$this, 'getRouteResult']);
-    }
-
-    /**
-     * Get the RouteResult instance of UrlHelper, if any.
-     */
-    public function getRouteResult() : ?RouteResult
-    {
-        return $this->urlHelper->getRouteResult();
-    }
-
-    /**
-     * Generate a URL from either the currently matched route or the specfied route.
-     *
-     * @param array  $options Can have the following keys:
-     *     - router (array): contains options to be passed to the router
-     *     - reuse_result_params (bool): indicates if the current RouteResult
-     *       parameters will be used, defaults to true
-     * @return string
-     */
-    public function generateUrl(
-        string $routeName = null,
-        array $routeParams = [],
-        array $queryParams = [],
-        ?string $fragmentIdentifier = null,
-        array $options = []
-    ) {
-        return $this->urlHelper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
-    }
-
-    /**
-     * Generate a fully qualified URI, relative to $path.
-     */
-    public function generateServerUrl(string $path = null) : string
-    {
-        return $this->serverUrlHelper->generate($path);
+        $engine->registerFunction('url', $this->urlHelper);
+        $engine->registerFunction('serverurl', $this->serverUrlHelper);
+        $engine->registerFunction('route', [$this->urlHelper, 'getRouteResult']);
     }
 }

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -51,4 +51,50 @@ class UrlExtension implements ExtensionInterface
         $engine->registerFunction('serverurl', $this->serverUrlHelper);
         $engine->registerFunction('route', [$this->urlHelper, 'getRouteResult']);
     }
+
+    /**
+     * Get the RouteResult instance of UrlHelper, if any.
+     *
+     * @deprecated since 2.2.0; to be removed in 3.0.0. This method was originally
+     *     used internally to back the route() Plates function; we now register
+     *     the UrlHelper::getRouteResult callback directly.
+     */
+    public function getRouteResult() : ?RouteResult
+    {
+        return $this->urlHelper->getRouteResult();
+    }
+
+    /**
+     * Generate a URL from either the currently matched route or the specfied route.
+     *
+     * @param array  $options Can have the following keys:
+     *     - router (array): contains options to be passed to the router
+     *     - reuse_result_params (bool): indicates if the current RouteResult
+     *       parameters will be used, defaults to true
+     * @return string
+     * @deprecated since 2.2.0; to be removed in 3.0.0. This method was originally
+     *     used internally to back the url() Plates function; we now register
+     *     UrlHelper instance directly, as it is callable.
+     */
+    public function generateUrl(
+        string $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        ?string $fragmentIdentifier = null,
+        array $options = []
+    ) {
+        return $this->urlHelper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
+    }
+
+    /**
+     * Generate a fully qualified URI, relative to $path.
+     *
+     * @deprecated since 2.2.0; to be removed in 3.0.0. This method was originally
+     *     used internally to back the serverurl() Plates function; we now register
+     *     the ServerUrl instance directly, as it is callable.
+     */
+    public function generateServerUrl(string $path = null) : string
+    {
+        return $this->serverUrlHelper->generate($path);
+    }
 }

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -54,4 +54,83 @@ class UrlExtensionTest extends TestCase
 
         $this->extension->register($engine->reveal());
     }
+
+    public function urlHelperParams()
+    {
+        return [
+            'null'             => [null, []],
+            'route-only'       => ['route', []],
+            'params-only'      => [null, ['param' => 'value']],
+            'route-and-params' => ['route', ['param' => 'value']],
+        ];
+    }
+
+    /**
+     * @dataProvider urlHelperParams
+     *
+     * @param null|string $route
+     * @param array $params
+     */
+    public function testGenerateUrlProxiesToUrlHelper($route, array $params)
+    {
+        $this->urlHelper->generate($route, $params, [], null, [])->willReturn('/success');
+        $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
+    }
+
+    public function testUrlHelperAcceptsQueryParametersFragmentAndOptions()
+    {
+        $this->urlHelper->generate(
+            'resource',
+            ['id' => 'sha1'],
+            ['foo' => 'bar'],
+            'fragment',
+            ['reuse_result_params' => true]
+        )->willReturn('PATH');
+
+        $this->assertEquals(
+            'PATH',
+            $this->extension->generateUrl(
+                'resource',
+                ['id' => 'sha1'],
+                ['foo' => 'bar'],
+                'fragment',
+                ['reuse_result_params' => true]
+            )
+        );
+    }
+
+    public function serverUrlHelperParams()
+    {
+        return [
+            'null'          => [null],
+            'absolute-path' => ['/foo/bar'],
+            'relative-path' => ['foo/bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider serverUrlHelperParams
+     *
+     * @param null|string $path
+     */
+    public function testGenerateServerUrlProxiesToServerUrlHelper($path)
+    {
+        $this->serverUrlHelper->generate($path)->willReturn('/success');
+        $this->assertEquals('/success', $this->extension->generateServerUrl($path));
+    }
+
+    public function testGetRouteResultReturnsRouteResultWhenPopulated()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $this->urlHelper->getRouteResult()->willReturn($result->reveal());
+
+        $this->assertInstanceOf(RouteResult::class, $this->extension->getRouteResult());
+    }
+
+    public function testGetRouteResultReturnsNullWhenRouteResultNotPopulatedInUrlHelper()
+    {
+        $this->urlHelper->getRouteResult()->willReturn(null);
+
+        $this->assertNull($this->extension->getRouteResult());
+    }
 }

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -43,94 +43,15 @@ class UrlExtensionTest extends TestCase
     {
         $engine = $this->prophesize(Engine::class);
         $engine
-            ->registerFunction('url', [$this->extension, 'generateUrl'])
+            ->registerFunction('url', $this->urlHelper)
             ->shouldBeCalled();
         $engine
-            ->registerFunction('serverurl', [$this->extension, 'generateServerUrl'])
+            ->registerFunction('serverurl', $this->serverUrlHelper)
             ->shouldBeCalled();
         $engine
-            ->registerFunction('route', [$this->extension, 'getRouteResult'])
+            ->registerFunction('route', [$this->urlHelper, 'getRouteResult'])
             ->shouldBeCalled();
 
         $this->extension->register($engine->reveal());
-    }
-
-    public function urlHelperParams()
-    {
-        return [
-            'null'             => [null, []],
-            'route-only'       => ['route', []],
-            'params-only'      => [null, ['param' => 'value']],
-            'route-and-params' => ['route', ['param' => 'value']],
-        ];
-    }
-
-    /**
-     * @dataProvider urlHelperParams
-     *
-     * @param null|string $route
-     * @param array $params
-     */
-    public function testGenerateUrlProxiesToUrlHelper($route, array $params)
-    {
-        $this->urlHelper->generate($route, $params, [], null, [])->willReturn('/success');
-        $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
-    }
-
-    public function testUrlHelperAcceptsQueryParametersFragmentAndOptions()
-    {
-        $this->urlHelper->generate(
-            'resource',
-            ['id' => 'sha1'],
-            ['foo' => 'bar'],
-            'fragment',
-            ['reuse_result_params' => true]
-        )->willReturn('PATH');
-
-        $this->assertEquals(
-            'PATH',
-            $this->extension->generateUrl(
-                'resource',
-                ['id' => 'sha1'],
-                ['foo' => 'bar'],
-                'fragment',
-                ['reuse_result_params' => true]
-            )
-        );
-    }
-
-    public function serverUrlHelperParams()
-    {
-        return [
-            'null'          => [null],
-            'absolute-path' => ['/foo/bar'],
-            'relative-path' => ['foo/bar'],
-        ];
-    }
-
-    /**
-     * @dataProvider serverUrlHelperParams
-     *
-     * @param null|string $path
-     */
-    public function testGenerateServerUrlProxiesToServerUrlHelper($path)
-    {
-        $this->serverUrlHelper->generate($path)->willReturn('/success');
-        $this->assertEquals('/success', $this->extension->generateServerUrl($path));
-    }
-
-    public function testGetRouteResultReturnsRouteResultWhenPopulated()
-    {
-        $result = $this->prophesize(RouteResult::class);
-        $this->urlHelper->getRouteResult()->willReturn($result->reveal());
-
-        $this->assertInstanceOf(RouteResult::class, $this->extension->getRouteResult());
-    }
-
-    public function testGetRouteResultReturnsNullWhenRouteResultNotPopulatedInUrlHelper()
-    {
-        $this->urlHelper->getRouteResult()->willReturn(null);
-
-        $this->assertNull($this->extension->getRouteResult());
     }
 }


### PR DESCRIPTION
The UrlExtension has basically duplicated UrlHelper and ServerUrlHelper methods proxying to them.
Plates calls to the registered function 'url' result in calling:

UrlExtension::generateUrl => UrlHelper::generate => UrlHelper::__invoke

Registering the invokable helpers directly (when possible) removed 2 redundant function calls :

Plates calls for 'url' result, for instance, in calling just UrlHelper::__invoke

The EscaperExtension uses the escaper's methods directly as well.